### PR TITLE
Explicitly triggered refresh 

### DIFF
--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { FlashMessage } from './flash-message';
 import { FlashMessagesService } from './flash-messages.service';
 import { FlashMessageInterface } from './flash-message.interface';
@@ -26,7 +26,7 @@ export class FlashMessagesComponent implements OnInit {
 
     private _flashMessagesElement: any;
 
-    constructor(private _flashMessagesService: FlashMessagesService) {
+    constructor(private _flashMessagesService: FlashMessagesService, private _cdRef: ChangeDetectorRef) {
         this._flashMessagesService.show = this.show.bind(this);
         this._flashMessagesService.grayOut = this.grayOut.bind(this);
     }
@@ -46,9 +46,11 @@ export class FlashMessagesComponent implements OnInit {
         
         let message = new FlashMessage(text, defaults.cssClass);
         this.messages.push(message);
+        this._cdRef.detectChanges();
         
         window.setTimeout(() => {
             this._remove(message);
+            this._cdRef.detectChanges();
         }, defaults.timeout);
     }
     


### PR DESCRIPTION
Hi !

I was experiencing some inconsistent refreshes upon adding multiple flash messages simultaneously with the show method. View did not refresh as supposed to.

So here is a little fix, if you approve it :

### Explicitly trigger refresh of the component view using ChangeDetectorRef

1. Added import of _ChangeDetectorRef_ from '_@angular/core_'
2. Added injection of _ChangeDectectorRef_ as `private _cdRef`
3. Called `detectChanges()` on `_cdRef` private member after insertion and removal of a message in order to explicitly refresh the view.

Note: I'm choosing _ChangeDetectorRef_ rather than `zone.run()` in order to detect component and children changes, and not traversing the entire tree. But if changes were about to happen outside the module, the second solution would be preferable.