### PR TITLE
Identify message by ID

### DIFF
--- a/module/flash-message.interface.ts
+++ b/module/flash-message.interface.ts
@@ -1,4 +1,5 @@
 export interface FlashMessageInterface {
+    id: number;
     text: string;
     cssClass: string;
 }

--- a/module/flash-message.ts
+++ b/module/flash-message.ts
@@ -1,6 +1,9 @@
 import { FlashMessageInterface } from './flash-message.interface';
 
 export class FlashMessage implements FlashMessageInterface {
+    static nextId = 0;
+    
+    id: number = (FlashMessage.nextId++);
     text: string = 'default text';
     cssClass: string = '';
     

--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -57,8 +57,6 @@ export class FlashMessagesComponent implements OnInit {
     }
 
     private _remove(message: FlashMessageInterface) {
-        this.messages = this.messages.filter(function(msg) {
-          return msg.text !== message.text;
-        });
+        this.messages = this.messages.filter((msg) => msg.id !== message.id);
     }
 }


### PR DESCRIPTION
Hi again

I saw that, on removal, messages are filtered by text. With this method, multiple messages having the same text will potentially be removed before the end of their timeout when the first one is firing. 
So I suggest to filter them by a unique property: 

### Added sequential id property to  FlashMessage to distinguish them

1. Added `id` property of type number in `FlashMessageInterface`
2. Added a static `nextId` variable in `FlashMessage` to save the next id value
3. Added the `id` property in `FlashMessage` and assigning it to the current next id value from `nextId` then increment the static var
4. Changed the closure provided to filter by an arrow function checking message comparing `id` property instead of `text` property

Note: This implementation with a static class variable is chosen for simplicity. Some other choices would be possible as well.