### PR TITLE
Support lazy loading

### DIFF
--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -6,7 +6,7 @@ import { FlashMessageInterface } from './flash-message.interface';
 @Component({
   selector: 'flash-messages',
   template: `
-      <div id="flashMessages" class="flash-messages {{classes}}">
+      <div id="flashMessages" class="flash-messages">
           <div id="grayOutDiv" *ngIf='_grayOut && messages.length'></div>
           <div class="alert flash-message {{message.cssClass}}" *ngFor='let message of messages'>
               <p>{{message.text}}</p>

--- a/module/module.ts
+++ b/module/module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, Optional, SkipSelf } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule }            from '@angular/common';
 import { FlashMessagesComponent }    from './flash-messages.component';
 import { FlashMessagesService }    from './flash-messages.service';

--- a/module/module.ts
+++ b/module/module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule, ModuleWithProviders, Optional, SkipSelf } from '@angular/core';
 import { CommonModule }            from '@angular/common';
 import { FlashMessagesComponent }    from './flash-messages.component';
 import { FlashMessagesService }    from './flash-messages.service';
@@ -7,6 +7,13 @@ import { FlashMessagesService }    from './flash-messages.service';
     imports:      [ CommonModule ],
     declarations: [ FlashMessagesComponent ],
     exports:      [ FlashMessagesComponent ],
-    providers:    [ FlashMessagesService ]
+    providers:    [ ]
 })
-export class FlashMessagesModule {}
+export class FlashMessagesModule {
+    static forRoot(): ModuleWithProviders {
+        return {
+            ngModule: FlashMessagesModule,
+            providers: [FlashMessagesService]
+        }
+    }
+}


### PR DESCRIPTION
To be able to use lazy loaded modules, a singleton instance of the FlashMessageService is needed and therefore the FlashMessagesModule must be imported in the application's root module with `FlashMessagesModule.forRoot()`. Otherwise it will cause problems because of child dependency injections. See http://blog.angular-university.io/angular2-ngmodule/ for further explanation.