### PR TITLE
Close button/action added

### DIFF
--- a/app/about/about.component.ts
+++ b/app/about/about.component.ts
@@ -14,7 +14,7 @@ export class AboutComponent {
     
     go() {
         this._flashMessagesService.grayOut(false);
-        this._flashMessagesService.show('we were in about' + Math.random(), { cssClass: 'alert-danger' });
+        this._flashMessagesService.show('we were in about' + Math.random(), { cssClass: 'alert-danger', showCloseBtn:true });
         this.router.navigate(['/']);
     }
 }

--- a/app/home/home.component.ts
+++ b/app/home/home.component.ts
@@ -14,7 +14,7 @@ export class HomeComponent {
     
     go() {
         this._flashMessagesService.grayOut(true);
-        this._flashMessagesService.show('we were at home' + Math.random(), { cssClass: 'alert-success', timeout: 3000 });
+        this._flashMessagesService.show('we were at home' + Math.random(), { cssClass: 'alert-success', timeout: 3000, closeOnClick:true });
         this.router.navigate(['/about']);
     }
 }

--- a/module/flash-message.interface.ts
+++ b/module/flash-message.interface.ts
@@ -2,4 +2,6 @@ export interface FlashMessageInterface {
     id: number;
     text: string;
     cssClass: string;
+    closeOnClick: boolean;
+    showCloseBtn: boolean;
 }

--- a/module/flash-message.ts
+++ b/module/flash-message.ts
@@ -7,11 +7,13 @@ export class FlashMessage implements FlashMessageInterface {
     text: string = 'default text';
     cssClass: string = '';
     closeOnClick: boolean = false;
+    showCloseBtn: boolean = false;
     timer: number;
     
-    constructor(text?: string, cssClass?: string, closeOnClick?:boolean) {
+    constructor(text?: string, cssClass?: string, closeOnClick?:boolean, showCloseBtn?:boolean) {
         this.text = text;
         this.cssClass = cssClass;
         this.closeOnClick = closeOnClick;
+        this.showCloseBtn = showCloseBtn;
     }
 }

--- a/module/flash-message.ts
+++ b/module/flash-message.ts
@@ -6,9 +6,12 @@ export class FlashMessage implements FlashMessageInterface {
     id: number = (FlashMessage.nextId++);
     text: string = 'default text';
     cssClass: string = '';
+    closeOnClick: boolean = false;
+    timer: number;
     
-    constructor(text?: string, cssClass?: string) {
+    constructor(text?: string, cssClass?: string, closeOnClick?:boolean) {
         this.text = text;
         this.cssClass = cssClass;
+        this.closeOnClick = closeOnClick;
     }
 }

--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -8,7 +8,8 @@ import { FlashMessageInterface } from './flash-message.interface';
   template: `
       <div id="flashMessages" class="flash-messages {{classes}}">
           <div id="grayOutDiv" *ngIf='_grayOut && messages.length'></div>
-          <div class="alert flash-message {{message.cssClass}}" [style.cursor]="message.closeOnClick?'pointer':'inherit'" *ngFor='let message of messages' (click)="alertClicked(message)">
+          <div class="alert flash-message {{message.cssClass}}" [ngClass]="{'alert-dismissible':message.showCloseBtn}" [style.cursor]="message.closeOnClick?'pointer':'inherit'" *ngFor='let message of messages' (click)="alertClicked(message)">
+              <button *ngIf="message.showCloseBtn" type="button" class="close" data-dismiss="alert" aria-label="Close" (click)="close(message)"><span aria-hidden="true">&times;</span></button>
               <p>{{message.text}}</p>
           </div> 
       </div>
@@ -18,6 +19,7 @@ export class FlashMessagesComponent implements OnInit {
     private _defaults = {
         text: 'default message',
         closeOnClick: false,
+        showCloseBtn: false,
         cssClass: ''
     };
 
@@ -38,12 +40,13 @@ export class FlashMessagesComponent implements OnInit {
         let defaults = {
           timeout: 2500,
           closeOnClick: false,
+          showCloseBtn: false,
           cssClass: ''
         };
         
         for (var attrname in options) { (<any>defaults)[attrname] = (<any>options)[attrname]; }
         
-        let message = new FlashMessage(text, defaults.cssClass, defaults.closeOnClick);
+        let message = new FlashMessage(text, defaults.cssClass, defaults.closeOnClick, defaults.showCloseBtn);
 
         message.timer = window.setTimeout(() => {
             this._remove(message);

--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -8,7 +8,7 @@ import { FlashMessageInterface } from './flash-message.interface';
   template: `
       <div id="flashMessages" class="flash-messages {{classes}}">
           <div id="grayOutDiv" *ngIf='_grayOut && messages.length'></div>
-          <div class="alert flash-message {{message.cssClass}}" *ngFor='let message of messages'>
+          <div class="alert flash-message {{message.cssClass}}" [style.cursor]="message.closeOnClick?'pointer':'inherit'" *ngFor='let message of messages' (click)="alertClicked(message)">
               <p>{{message.text}}</p>
           </div> 
       </div>
@@ -17,6 +17,7 @@ import { FlashMessageInterface } from './flash-message.interface';
 export class FlashMessagesComponent implements OnInit {
     private _defaults = {
         text: 'default message',
+        closeOnClick: false,
         cssClass: ''
     };
 
@@ -36,19 +37,33 @@ export class FlashMessagesComponent implements OnInit {
         
         let defaults = {
           timeout: 2500,
+          closeOnClick: false,
           cssClass: ''
         };
         
         for (var attrname in options) { (<any>defaults)[attrname] = (<any>options)[attrname]; }
         
-        let message = new FlashMessage(text, defaults.cssClass);
-        this.messages.push(message);
-        this._cdRef.detectChanges();
+        let message = new FlashMessage(text, defaults.cssClass, defaults.closeOnClick);
 
-        window.setTimeout(() => {
+        message.timer = window.setTimeout(() => {
             this._remove(message);
             this._cdRef.detectChanges();
         }, defaults.timeout);
+
+        this.messages.push(message);
+        this._cdRef.detectChanges();
+    }
+
+    close(message:FlashMessage): void {
+            clearTimeout(message.timer);
+            this._remove(message);
+            this._cdRef.detectChanges();
+    }
+
+    alertClicked(message:FlashMessage): void {
+      if(message.closeOnClick){
+        this.close(message);
+      }
     }
     
     grayOut(value = false) {


### PR DESCRIPTION
Hi,

I've added a (optional) close button as mentiond in #13.
There is also an option to close the flash message by clicking on it.
Both are configurable options and are false by default.

You can use it like this:
```js
// Close by clicking anywhere on the message
this._flashMessagesService.show('we were at home', { cssClass: 'alert-success', timeout: 3000, closeOnClick:true });

// Close by clicking on the close button
this._flashMessagesService.show('we were at home', { cssClass: 'alert-success', timeout: 3000, showCloseBtn:true });
```