### PR TITLE
Remove p tags

### DIFF
--- a/module/flash-messages.component.ts
+++ b/module/flash-messages.component.ts
@@ -9,7 +9,7 @@ import { FlashMessageInterface } from './flash-message.interface';
       <div id="flashMessages" class="flash-messages {{classes}}">
           <div id="grayOutDiv" *ngIf='_grayOut && messages.length'></div>
           <div class="alert flash-message {{message.cssClass}}" *ngFor='let message of messages'>
-              <p>{{message.text}}</p>
+              {{message.text}}
           </div> 
       </div>
   `


### PR DESCRIPTION
P tags around the text of the message interferes with bootstrap styles.
Originally, bootstrap doesn't use the p tags with alert messages text: https://getbootstrap.com/docs/4.0/components/alerts/